### PR TITLE
Move change from cweb.1 to cweb.man.

### DIFF
--- a/texk/web2c/cwebdir/ChangeLog
+++ b/texk/web2c/cwebdir/ChangeLog
@@ -1,8 +1,3 @@
-2018-10-20  Karl Berry  <karl@tug.org>
-
-	* cweb.1: do not mention nonexistent -DSTAT option.
-	From Andreas Scherer, tex-k 20 Oct 2018 16:26:14.
-
 2018-01-18  Karl Berry  <karl@tug.org>
 
 	* cweave.w,

--- a/texk/web2c/cwebdir/cweb.1
+++ b/texk/web2c/cwebdir/cweb.1
@@ -1,4 +1,4 @@
-.TH CWEB 1 2018-10-20
+.TH CWEB 1L 2002-Apr-13
 .
 .SH NAME
 ctangle, cweave \- translate CWEB to C and/or TeX
@@ -78,7 +78,8 @@ If you say -bhp, you get nothing but error messages.
 .PP
 The
 .B +s
-option prints statistics about memory usage at the end of a run.
+option prints statistics about memory usage at the end of a run
+(assuming that the programs have been compiled with the -DSTAT switch).
 .PP
 There are three other options applicable to
 .I cweave

--- a/texk/web2c/man/ChangeLog
+++ b/texk/web2c/man/ChangeLog
@@ -1,3 +1,7 @@
+2018-10-28  Andreas Scherer  <https://ascherer.github.io>
+
+	* cweb.man: do not mention nonexistent -DSTAT option.
+
 2018-06-04  Karl Berry  <karl@tug.org>
 
 	* Makefile.am (man_sources, man1_links) [PTEX]: add ptex.man.

--- a/texk/web2c/man/cweb.man
+++ b/texk/web2c/man/cweb.man
@@ -1,4 +1,4 @@
-.TH CWEB 1 "7 April 2010" "Web2C @VERSION@"
+.TH CWEB 1 "28 October 2018" "Web2C @VERSION@"
 .\"=====================================================================
 .SH NAME
 ctangle, cweave \- translate CWEB to C and/or TeX
@@ -90,8 +90,7 @@ you get nothing but error messages.
 .PP
 The
 .B +s
-option prints statistics about memory usage at the end of a run
-(assuming that the programs have been compiled with the -DSTAT switch).
+option prints statistics about memory usage at the end of a run.
 .PP
 There are three other options applicable to
 .B cweave


### PR DESCRIPTION
On close inspection it appears that TL does not use the original `cweb.1` from the CWEB tarball, but its own reformatted `cweb.man`. So we have to remove the long obsolete reference to the `STAT` compiler
switch from the latter file.