### PR TITLE
Update protos.h

### DIFF
--- a/texk/dvipsk/protos.h
+++ b/texk/dvipsk/protos.h
@@ -278,7 +278,7 @@ extern integer maxsecsize;
 extern integer firstboploc;
 extern Boolean sepfiles;
 extern int numcopies;
-extern const char *oname;
+extern char *oname;
 extern char *iname;
 extern char *fulliname;
 extern char *nextstring, *maxstring;


### PR DESCRIPTION
declaring const *oname will prevent its change on option -o for djgpp compiling for msdos and produce " error: conflicting types for ‘oname’ " on compilation.