### PR TITLE
Fix a stupid bug (large format like stress.tex produced segfault)

### DIFF
--- a/texk/web2c/eptexdir/tests/comp-tests/stress.tex
+++ b/texk/web2c/eptexdir/tests/comp-tests/stress.tex
@@ -1,0 +1,20 @@
+\let\origdump=\dump\let\dump\relax
+\batchmode
+\input eptex.ini
+\let\dump\origdump
+
+\count0=0
+\def\A{\ifnum\count0<450000
+  \edef\N{\the\numexpr1000000+\count0}
+  \expandafter\xdef\csname HOGE\N\endcsname{ABCDEFGHI}%
+  \advance\count0 by1\let\next=\A\else\let\next\relax
+  \fi\next}
+\A
+\count0=0
+\def\A{\ifnum\count0<120
+  \edef\N{\the\numexpr1000000+\count0}
+  \font\S=cmr10 at \N sp\fontdimen65536\S=1sp
+  \advance\count0 by1\let\next=\A\else\let\next\relax
+  \fi\next}
+\A
+\dump


### PR DESCRIPTION
* Removed 'inline' in `write_fmtbuffer` and `read_fmtbuffer`, since some compiler(?) causes
  `Undefined reference` error at linking.
* Stupid typo in `write_fmtbuffer`; this causes SegFault error in some situation (e.g., stress.tex).
* Added stress.tex; this produces very large format files
  (uncompressed: 115.3 MiB, compressed 28.4 MiB(`-comp level 1`), 27.6MiB (default)).
