### PR TITLE
Fix uninitialized read in m-tx grep function

### DIFF
--- a/utils/m-tx/mtx-src/utility.c
+++ b/utils/m-tx/mtx-src/utility.c
@@ -307,6 +307,7 @@ void grep(Char *source_, Char *pattern_, Char *target)
     V.p1[V.i] = 1;
     V.p2[V.i] = 0;
   }
+  V.matching = 0;
   while (V.matching && V.p <= strlen(V.pattern) && V.s <= strlen(V.source))
     subgrep(&V);
   *product = '\0';


### PR DESCRIPTION
The m-tx grep function reads uninitialized stack memory.
This patch just sets the initial value to 1 which allows
the while function that uses it uninitialized to run
as before.

```
void grep(Char *source_, Char *pattern_, Char *target)
{
  struct LOC_grep V;
  [...]
  // NOTE: All members aside from 'matching' initialized.
  V.source = source_;
  V.pattern = pattern_;
  V.index = 0;
  V.s = 1;
  V.p = 1;
  for (V.i = 0; V.i <= 9; V.i++) {
    V.p1[V.i] = 1;
    V.p2[V.i] = 0;
  }
  // NOTE: vvvvvvvv use of uninitialized member 'matching'.
  while (V.matching && V.p <= strlen(V.pattern) && V.s <= strlen(V.source))
```