### PR TITLE
Fix topskip for XeTeXupwardsmode

### DIFF
--- a/texk/web2c/xetexdir/xetex.web
+++ b/texk/web2c/xetexdir/xetex.web
@@ -22995,8 +22995,16 @@ end;
 @ @<Insert glue for |split_top_skip|...@>=
 begin q:=new_skip_param(split_top_skip_code); link(prev_p):=q; link(q):=p;
   {now |temp_ptr=glue_ptr(q)|}
-if width(temp_ptr)>height(p) then width(temp_ptr):=width(temp_ptr)-height(p)
-else width(temp_ptr):=0;
+if XeTeX_upwards then
+  begin
+    if width(temp_ptr)>depth(p) then width(temp_ptr):=width(temp_ptr)-depth(p)
+    else width(temp_ptr):=0;
+  end
+else
+  begin
+    if width(temp_ptr)>height(p) then width(temp_ptr):=width(temp_ptr)-height(p)
+    else width(temp_ptr):=0;
+  end;
 p:=null;
 end
 
@@ -23632,8 +23640,16 @@ endcases
 begin if page_contents=empty then freeze_page_specs(box_there)
 else page_contents:=box_there;
 q:=new_skip_param(top_skip_code); {now |temp_ptr=glue_ptr(q)|}
-if width(temp_ptr)>height(p) then width(temp_ptr):=width(temp_ptr)-height(p)
-else width(temp_ptr):=0;
+if XeTeX_upwards then
+  begin
+    if width(temp_ptr)>depth(p) then width(temp_ptr):=width(temp_ptr)-depth(p)
+    else width(temp_ptr):=0;
+  end
+else
+  begin
+    if width(temp_ptr)>height(p) then width(temp_ptr):=width(temp_ptr)-height(p)
+    else width(temp_ptr):=0;
+  end;
 link(q):=p; link(contrib_head):=q; goto continue;
 end
 


### PR DESCRIPTION
When \XeTeXupwards mode is active (non-zero) line spacing calculations are inverted, that is the lineskip is calculated as \baselineskip - height(line-1) - depth(line), instead of the normal \baselineskip - depth(line-1) - height(line). This works fine. But the lineskip calculation at the top of a page or vsplit needs also to be inverted. This PR fixes that.