### PR TITLE
gh workflow: update actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
     name: i386-linux build job
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: TeX-Live/tl-build-docker-action
           ref: v4
@@ -64,9 +64,9 @@ jobs:
     name: x86_64-linux build job
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: TeX-Live/tl-build-docker-action
           ref: v4
@@ -91,9 +91,9 @@ jobs:
     name: x86_64-linuxmusl build job
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: TeX-Live/tl-build-docker-action
           ref: v4


### PR DESCRIPTION
`actions/checkout@v2` runs on node 12 which will soon be deprecated, see 
- warnings thrown by a successful workflow run https://github.com/TeX-Live/texlive-source/actions/runs/4286775989
- GitHub blog https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

![image](https://user-images.githubusercontent.com/6376638/221746775-49295e16-a9d6-4c25-af0d-2389e0ac4685.png)
