### PR TITLE
luazlip: drop zlib library version check

### DIFF
--- a/texk/web2c/luatexdir/luazlib/lzlib.c
+++ b/texk/web2c/luatexdir/luazlib/lzlib.c
@@ -544,14 +544,6 @@ LUALIB_API int luaopen_zlib(lua_State *L)
 
     /* ====================================================================== */
 
-    /* make sure header and library version are consistent */
-    const char* version = zlibVersion();
-    if (strncmp(version, ZLIB_VERSION, 4))
-    {
-        lua_pushfstring(L, "zlib library version does not match - header: %s, library: %s", ZLIB_VERSION, version);
-        lua_error(L);
-    }
-
     /* create new metatable for zlib compression structures */
     luaL_newmetatable(L, ZSTREAMMETA);
     lua_pushliteral(L, "__index");


### PR DESCRIPTION
Found while preparing TeX Live 2023 packages for Gentoo, which today stabilized zlib 1.3:

Checking for the zlib library version breaks when zlib is updated to e.g., 1.3, as it causes

PANIC: unprotected error in call to Lua API (zlib library version does
not match - header: 1.2.13, library: 1.3)

However zlib never broke ABI. And such version checks are a common cause for breakage [1, 2]. Therefore, simply drop it.

1: https://github.com/madler/pigz/issues/111
2: https://github.com/noxxi/p5-io-socket-ssl/issues/137


Thanks-to: Sam James <sam@gentoo.org>