### PR TITLE
add a conditional statement to avoid fread size too big to coredump

### DIFF
--- a/texk/ttfdump/libttf/hdmx.c
+++ b/texk/ttfdump/libttf/hdmx.c
@@ -44,7 +44,11 @@ static void ttfLoadHDMX (FILE *fp,HDMXPtr hdmx,ULONG offset)
 	    hdmx->Records[i].PixelSize = ttfGetBYTE(fp);
 	    hdmx->Records[i].MaxWidth = ttfGetBYTE(fp);
 	    hdmx->Records[i].Width = XCALLOC (hdmx->size, BYTE);
-	    fread ((hdmx->Records+i)->Width, sizeof(BYTE), hdmx->numGlyphs+1,fp);
+	    //if hdmx->numGlyphs+1 > hdmx->size,it will coredump,so we read min(hdmx->numGlyphs+1,hdmx->size) and truncate the remainder.
+	    if (hdmx->numGlyphs+1 <= hdmx->size)
+	    	fread ((hdmx->Records+i)->Width, sizeof(BYTE), hdmx->numGlyphs+1,fp);
+	    else
+		fread ((hdmx->Records+i)->Width, sizeof(BYTE), hdmx->size,fp);
 	}
 }
 


### PR DESCRIPTION
The function `ttfLoadHDMX` uses the parsed hdmx size to allocate a Width heap buffer, copies content from the file, and the copy size is determined by numGlyphs. There is no validation of the actual memory size before storing it. Due to the controllable content and size, this could potentially lead to a heap overflow and result in arbitrary code execution.