### PR TITLE
kpathsea: don't depend on GNU libtool internals

### DIFF
--- a/texk/kpathsea/tests/kpsereadlink.test
+++ b/texk/kpathsea/tests/kpsereadlink.test
@@ -6,9 +6,16 @@
 
 test "x$LN_S" = 'xln -s' || exit 77
 
-./kpsereadlink $LT_OBJDIR/libkpathsea.lai && exit 1
+rm -f _test_file _test_symlink
 
-link=`./kpsereadlink $LT_OBJDIR/libkpathsea.la` || exit 1
+touch _test_file
 
-test "x$link" = x../libkpathsea.la || exit 1
+$LN_S _test_file _test_symlink || exit 1
 
+./kpsereadlink _test_file && exit 1
+
+link=`./kpsereadlink _test_symlink` || exit 1
+
+test "x$link" = x_test_file || exit 1
+
+rm -f _test_file _test_symlink


### PR DESCRIPTION
The `kpsereadlink.test` script checks that the compiled `kpsereadlink` correctly finds that `.libs/libkpathsea.lai` is not a symlink and that `.libs/libkpathsea.la` is a symlink.

However this assumption is broken when using slibtool instead of GNU libtool which creates `libpathsea.lai` as a symlink.

A more robust test that works with both GNU libtool and slibtool would be to create a file and symlink to test against rather than to depend on GNU libtool internals.

This was reported for Gentoo: https://bugs.gentoo.org/924405