### PR TITLE
m-tex: fix declaration of strpos2()

### DIFF
--- a/utils/m-tx/mtx-src/cfuncs.h
+++ b/utils/m-tx/mtx-src/cfuncs.h
@@ -64,7 +64,7 @@ extern void toUpper(char *s);
 extern void delete1(char *s, short p);
 extern void predelete(char *s, short l);
 extern void shorten(char *s, short new_length);
-extern short strpos2 (char *s1, char *s2, short p);
+extern short strpos2 (char *s1, char *s2, int p);
 extern short nextWordBound(char *s, char trigger, short p);
 
 #undef vextern


### PR DESCRIPTION
The 'pos' argument (third argument) is declared as an 'int' in p2clib.c, not a short.

Downstream Gentoo bug: https://bugs.gentoo.org/915223