### PR TITLE
mpfi: drop undefined MPFI_CONFIGS

### DIFF
--- a/libs/mpfi/configure
+++ b/libs/mpfi/configure
@@ -6158,8 +6158,6 @@ fi
 eval kpse_build_alias=\${build_alias-$build}
 
 
-MPFI_CONFIGS
-
  if test "x$enable_build" != xno; then
   build_TRUE=
   build_FALSE='#'

--- a/libs/mpfi/configure.ac
+++ b/libs/mpfi/configure.ac
@@ -26,8 +26,6 @@ AC_CONFIG_HEADERS([mpfi_config.h])
 
 KPSE_CANONICAL_HOST
 
-MPFI_CONFIGS
-
 AM_CONDITIONAL([build], [test "x$enable_build" != xno])
 
 KPSE_GMP_FLAGS


### PR DESCRIPTION
As reported in downstream bug https://bugs.gentoo.org/945908 MPFI_CONFIGS is not defined anywhere.

Not sure if this is the correct solution, but something is wrong about `MPFI_CONFIGS`.