### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/texk/web2c/mfluadir/otfcc/dep/extern/sds.c
+++ b/texk/web2c/mfluadir/otfcc/dep/extern/sds.c
@@ -193,7 +193,7 @@ void sdsclear(sds s) {
 sds sdsMakeRoomFor(sds s, size_t addlen) {
     void *sh, *newsh;
     size_t avail = sdsavail(s);
-    size_t len, newlen;
+    size_t len, newlen, reqlen;
     char type, oldtype = s[-1] & SDS_TYPE_MASK;
     int hdrlen;
 
@@ -202,7 +202,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
 
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
-    newlen = (len+addlen);
+    reqlen = newlen = (len+addlen);
     if (newlen < SDS_MAX_PREALLOC)
         newlen *= 2;
     else
@@ -216,6 +216,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
+    assert(hdrlen + newlen + 1 > reqlen);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc(sh, hdrlen+newlen+1);
         if (newsh == NULL) return NULL;


### PR DESCRIPTION
This PR fixes a potential security vulnerability in texk/web2c/mfluadir/otfcc/dep/extern/sds.c

###Details:
Affected File: texk/web2c/mfluadir/otfcc/dep/extern/sds.c
Original Fix: https://github.com/redis/redis/commit/c6ad876774f3cc11e32681ea02a2eead00f2c521


###What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

###References:
- https://nvd.nist.gov/vuln/detail/CVE-2021-41099