### PR TITLE
Disable hilatex format in fmtutil.cnf

### DIFF
--- a/texk/texlive/tl_support/fmtutil.cnf
+++ b/texk/texlive/tl_support/fmtutil.cnf
@@ -65,7 +65,7 @@ pdfcsplain xetex - -etex csplain.ini
 eplain pdftex language.dat -translate-file=cp227.tcx *eplain.ini
 #
 # from hitex:
-hilatex hitex language.dat -etex -ltx hilatex.ini
+# hilatex hitex language.dat -etex -ltx hilatex.ini
 hitex hitex language.def -etex -ltx hitex.ini
 #
 # from jadetex:


### PR DESCRIPTION
`fmtutil-sys --all` fails when generating `hilatex.fmt` (`no (or empty) hilatex.fmt made by hitex`).

Disable only the `hilatex` format entry for now; keep `hitex` enabled.

Ref: https://github.com/Homebrew/homebrew-core/pull/270246
