### PR TITLE
xdvipsk: support building manpage with system kpathsea

### DIFF
--- a/texk/xdvipsk/configure.ac
+++ b/texk/xdvipsk/configure.ac
@@ -45,6 +45,28 @@ AC_DEFINE([TL_VERSION], ["TeX Live tex_live_version()"],
           [Define to the current TeX Live version string.])
 
 KPSE_KPATHSEA_FLAGS
+
+if test "x$with_system_kpathsea" = xyes; then
+  # We want to support building xdvipsk
+  # using installed (system) kpathsea headers and library.
+  # In that case we need the location of <kpathsea/paths.h>.
+  list="/usr/include /usr/local/include `echo $KPATHSEA_INCLUDES | sed 's/-I//g'`"
+  found=no
+  for KPATHSEA_PATHS_H in $list; do
+    if test -r "$KPATHSEA_PATHS_H/kpathsea/paths.h"; then
+      found=yes
+      break
+    fi
+  done
+  if test "x$found" = xno; then
+    AC_MSG_NOTICE([You requested to build `xdvipsk' using an installed `kpathsea' version,])
+    AC_MSG_NOTICE([    which requires to locate the <kpathsea/paths.h> header file.])
+    AC_MSG_ERROR([Sorry, not found under any of: $list *****])
+  fi
+else
+  KPATHSEA_PATHS_H='${top_builddir}/..'
+fi
+AC_SUBST([KPATHSEA_PATHS_H])
 KPSE_LUA53_FLAGS
 KPSE_ZLIB_FLAGS
 KPSE_LIBPNG_FLAGS

--- a/texk/xdvipsk/man/Makefile.am
+++ b/texk/xdvipsk/man/Makefile.am
@@ -10,6 +10,6 @@ man_sources = \
 
 EXTRA_DIST = $(man_sources)
 
-KPATHSEA_PATHS_H = ${top_builddir}/..
+KPATHSEA_PATHS_H = @KPATHSEA_PATHS_H@
 
 include $(top_srcdir)/../../am/man.am


### PR DESCRIPTION
When building xdvipsk with --with-system-kpathsea, KPATHSEA_PATHS_H was hardcoded to ${top_builddir}/.. in man/Makefile.am which caused a build failure because paths.h could not be found. This fix resolves KPATHSEA_PATHS_H in configure.ac similar to how web2c does it.