### PR TITLE
XeTeX: preserve filedump offsets beyond 16 bits

### DIFF
--- a/texk/web2c/xetexdir/tests/filedump.log
+++ b/texk/web2c/xetexdir/tests/filedump.log
@@ -1,5 +1,24 @@
  restricted \write18 enabled.
  %&-line parsing enabled.
 **filedump
-(./filedump.tex 25C2AA0A5C636174636F6465605C7B3D310A5C63 )
+(./filedump.tex
+25C2AA0A5C636174636F6465605C7B3D310A5C63
+0:78,32767:78,32768:41,65535:42,65536:43,70000:44
+at-eof:44,past-eof:44,after-eof:,zero-length:
+! Bad file offset (-1).
+l.18 \message{negative-offset:\filedump offset -1 
+                                                  length 1{filedump-data}}
+A file offset must be between 0 and 2^{31}-1,
+I changed this one to zero.
+
+negative-offset:78
+! Bad dump length (-1).
+<to be read again> 
+                   {
+l.19 \message{negative-length:\filedump length -1{
+                                                  filedump-data}}
+A dump length must be between 0 and 2^{31}-1,
+I changed this one to zero.
+
+negative-length: )
 No pages of output.

--- a/texk/web2c/xetexdir/tests/filedump.tex
+++ b/texk/web2c/xetexdir/tests/filedump.tex
@@ -1,5 +1,20 @@
 %ª
 \catcode`\{=1
 \catcode`\}=2
+\nonstopmode
 \message{\filedump length 20{\jobname.tex}}
+\message{%
+  0:\filedump length 1{filedump-data},%
+  32767:\filedump offset 32767 length 1{filedump-data},%
+  32768:\filedump offset 32768 length 1{filedump-data},%
+  65535:\filedump offset 65535 length 1{filedump-data},%
+  65536:\filedump offset 65536 length 1{filedump-data},%
+  70000:\filedump offset 70000 length 1{filedump-data}}
+\message{%
+  at-eof:\filedump offset 70000 length 1{filedump-data},%
+  past-eof:\filedump offset 70000 length 2{filedump-data},%
+  after-eof:\filedump offset 70001 length 1{filedump-data},%
+  zero-length:\filedump length 0{filedump-data}}
+\message{negative-offset:\filedump offset -1 length 1{filedump-data}}
+\message{negative-length:\filedump length -1{filedump-data}}
 \end

--- a/texk/web2c/xetexdir/xetex-filedump.test
+++ b/texk/web2c/xetexdir/xetex-filedump.test
@@ -13,12 +13,18 @@ TEXINPUTS=".;$srcdir/tests"; export TEXINPUTS
 TEXFORMATS=.; export TEXFORMATS
 
 # get same filename in log
-rm -f filedump.tex
+rm -f filedump.tex filedump-data
+trap 'rm -f filedump-data' 0 1 2 3 15
 $LN_S $srcdir/xetexdir/tests/filedump.tex .
+
+perl -e 'print "x" x 32768, "A", "x" x 32766, "B", "C", "x" x 4463, "D";' \
+  >filedump-data || exit 1
 
 #exit 77
 
-$_xetex -ini filedump || exit 1
+# Negative offset and length are TeX errors, but \nonstopmode continues.
+$_xetex -ini filedump
+test -f filedump.log || exit 1
 
 sed 1d filedump.log >filedump.out
 

--- a/texk/web2c/xetexdir/xetex.web
+++ b/texk/web2c/xetexdir/xetex.web
@@ -11114,7 +11114,7 @@ var old_setting:0..max_selector; {holds |selector| setting}
 @!b:pool_pointer; {base of temporary string}
 @!fnt,@!arg1,@!arg2:integer; {args for \XeTeX\ extensions}
 @!font_name_str:str_number; {local vars for \.{\\fontname} quoting extension}
-@!i:small_number;
+@!i:integer;
 @!quote_char:UTF16_code;
 @!cat:small_number; {desired catcode, or 0 for automatic |spacer|/|other_char| selection}
 @!saved_chr:UnicodeScalar;


### PR DESCRIPTION
Fixes #88.

XeTeX stored the parsed `\\filedump` offset in `small_number`, truncating
values at the 16-bit boundary before `getfiledump` received them. Store the
offset in `integer`, matching the helper's argument type.

The first commit adds a regression fixture with sentinel bytes around the
16-bit boundary, together with EOF and invalid-argument cases. The second
commit contains the one-line fix.

Tested:

- `make xetex`
- `xetex-filedump.test`
